### PR TITLE
Support QNX by using lower-level I/O

### DIFF
--- a/entropy.cabal
+++ b/entropy.cabal
@@ -34,6 +34,8 @@ Library
   if os(windows)
     cpp-options: -DisWindows
     extra-libraries: advapi32
+  else
+    Build-Depends: unix
 
 source-repository head
     type:       git


### PR DESCRIPTION
GHC's high-level openFile, etc, require the ability to identify the type
of the file (directory, link, etc) in order to be able to open it.  The
set of type supported is incomplete, but that's not the only problem.
Some systems (such as QNX) have /dev/urandom set up as a type of file
that _only exists on that OS_.  This is unlikely to gain proper support
in GHC's high-level calls at all.

Luckily, we do not need to know the type of the file in order to read it
with lower-level POSIX calls.  Since /dev/urandom is something we're
assuming exists when on UNIX-like systems anyway, using POSIX calls in
order to read it should be safe and preserve portability to all
existingly-supported platforms, but will additionally allow the library
to support QNX (and possibly others).
