### PR TITLE
Catching up Cabal-1.17.

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 import Distribution.Simple
 import Distribution.Simple.LocalBuildInfo
 import Distribution.Simple.Setup
@@ -32,7 +34,11 @@ cArgsHC = map ("-optc" ++) cArgs
 
 canUseRDRAND :: FilePath -> IO Bool
 canUseRDRAND cc = do
+#if __GLASGOW_HASKELL__ >= 707
+        withTempDirectory normal False "" "testRDRAND" $ \tmpDir -> do
+#else
         withTempDirectory normal "" "testRDRAND" $ \tmpDir -> do
+#endif
         writeFile (tmpDir ++ "/testRDRAND.c")
                 (unlines        [ "#include <stdint.h>"
                                 , "int main() {"


### PR DESCRIPTION
withTempDirectory in Cabal 1.17 takes one more argument.
We cannot use the version of Cabal because entropy.cabal
does not have the dependency for Cabal. Instead, this patch
uses the version of GHC.
