### PR TITLE
Fix with 7.4 and 7.6 and make travis test them

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,5 @@
 language: haskell
+ghc:
+  - 7.8
+  - 7.6
+  - 7.4

--- a/entropy.cabal
+++ b/entropy.cabal
@@ -18,7 +18,7 @@ stability:      stable
 -- ^^ Used for HaLVM
 build-type:        Custom
 -- ^^ Test for RDRAND support using 'ghc'
-cabal-version:  >=1.17
+cabal-version:  >=1.10
 tested-with:    GHC == 7.8.2
 -- data-files:
 extra-source-files:   ./cbits/rdrand.c, ./cbits/rdrand.h, README.md


### PR DESCRIPTION
This works for me.  I added the travis tests as a check.  GHC 7.6 comes with Cabal 1.16.  I'm not sure what 7.4 comes with, but since 1.10 seemed to work when I reported the 7.0 problem before I figured it would be a safe bet here.  Travis hasn't finished running the tests yet, but I thought I'd send this along anyway.
