### PR TITLE
Restore compatibility with GHC 7.0 and GHC 7.2

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+import Control.Monad
 import Distribution.Simple
 import Distribution.Simple.LocalBuildInfo
 import Distribution.Simple.Setup
@@ -9,6 +11,7 @@ import System.Process
 import System.Directory
 import System.FilePath
 import System.Exit
+import System.IO
 
 main = defaultMainWithHooks hk
  where
@@ -44,6 +47,30 @@ canUseRDRAND cc = do
                                 , "   return (!err);"
                                 , "}"
                                 ])
-        ec <- rawSystemExitCode normal cc [tmpDir </> "testRDRAND.c", "-o", tmpDir ++ "/a.o","-c"]
+        ec <- myRawSystemExitCode normal cc [tmpDir </> "testRDRAND.c", "-o", tmpDir ++ "/a.o","-c"]
         notice normal $ "Result of RDRAND Test: " ++ show (ec == ExitSuccess)
         return (ec == ExitSuccess)
+
+myRawSystemExitCode :: Verbosity -> FilePath -> [String] -> IO ExitCode
+#if __GLASGOW_HASKELL__ >= 704
+-- We know for sure, that if GHC >= 7.4 implies Cabal >= 1.14
+myRawSystemExitCode = rawSystemExitCode
+#else
+-- Legacy branch:
+-- We implement our own 'rawSystemExitCode', this will even work if
+-- the user happens to have Cabal >= 1.14 installed with GHC 7.0 or
+-- 7.2
+myRawSystemExitCode verbosity path args = do
+    printRawCommandAndArgs verbosity path args
+    hFlush stdout
+    exitcode <- rawSystem path args
+    unless (exitcode == ExitSuccess) $ do
+        debug verbosity $ path ++ " returned " ++ show exitcode
+    return exitcode
+  where
+    printRawCommandAndArgs :: Verbosity -> FilePath -> [String] -> IO ()
+    printRawCommandAndArgs verbosity path args
+      | verbosity >= deafening = print (path, args)
+      | verbosity >= verbose = putStrLn $ unwords (path : args)
+      | otherwise = return ()
+#endif

--- a/entropy.cabal
+++ b/entropy.cabal
@@ -42,7 +42,7 @@ library
          other-modules: System.EntropyNix
   }
   other-extensions:    CPP, ForeignFunctionInterface, BangPatterns, ScopedTypeVariables
-  build-depends: base >= 4.5 && < 5, bytestring
+  build-depends: base >= 4.3 && < 5, bytestring
   default-language:    Haskell2010
   if(os(halvm))
     cpp-options: -DXEN -DHAVE_RDRAND


### PR DESCRIPTION
This addresses #23 (and #17) by using a variant of #18 that
is more careful in its assumptions.

PS: you can see in https://ghc.haskell.org/~hvr/buildreports/Cabal.html why we can assume that GHC>=7.4 implies Cabal >= 1.14