### PR TITLE
Use ghcProgram in Setup.hs script

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -17,8 +17,7 @@ main = defaultMainWithHooks hk
  where
  hk = simpleUserHooks { buildHook = \pd lbi uh bf -> do
                                         -- let ccProg = Program "gcc" undefined undefined undefined
-                                        let hcProg = Program "ghc" undefined undefined undefined
-                                            mConf  = lookupProgram hcProg (withPrograms lbi)
+                                        let mConf  = lookupProgram ghcProgram (withPrograms lbi)
                                             err    = error "Could not determine C compiler"
                                             cc     = locationPath . programLocation  . maybe err id $ mConf
                                         b <- canUseRDRAND cc


### PR DESCRIPTION
The `Program` constructor's type has changed in `Cabal-2.3`, so `Program "ghc" undefined undefined undefined` no longer typechecks with that version of `Cabal`. Using `ghcProgram` instead is a simple way of achieving forwards- and backwards-compatibility.