### PR TITLE
add os(ghcjs)

### DIFF
--- a/entropy.cabal
+++ b/entropy.cabal
@@ -43,7 +43,7 @@ custom-setup
 library
   ghc-options:  -O2
   exposed-modules: System.Entropy
-  if impl(ghcjs)
+  if impl(ghcjs) || os(ghcjs)
     other-modules: System.EntropyGhcjs
   else {
     if os(windows)
@@ -60,8 +60,8 @@ library
   build-depends:       base >= 4.8 && < 5, bytestring
 
   default-language:    Haskell2010
-  
-  if impl(ghcjs) {
+
+  if impl(ghcjs) || os(ghcjs) {
     build-depends:     ghcjs-dom
                      , jsaddle
   }


### PR DESCRIPTION
This adds `os(ghcjs)` in preparation for a ghcjs that is merged with ghc, at which point it won't report as a separate implementation anymore.