### PR TITLE
Fix the build with Clang on Windows

### DIFF
--- a/System/EntropyWindows.hs
+++ b/System/EntropyWindows.hs
@@ -31,21 +31,20 @@ import Foreign.Marshal.Alloc (alloca)
 import Foreign.Marshal.Utils (toBool)
 import Foreign.Storable (peek)
 
-{- C example for windows rng - taken from a blog, can't recall which one but thank you!
-        #include <Windows.h>
-        #include <Wincrypt.h>
-        ...
-        //
-        // DISCLAIMER: Don't forget to check your error codes!!
-        // I am not checking as to make the example simple...
-        //
-        HCRYPTPROV hCryptCtx = NULL;
-        BYTE randomArray[128];
-
-        CryptAcquireContext(&hCryptCtx, NULL, MS_DEF_PROV, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT);
-        CryptGenRandom(hCryptCtx, 128, randomArray);
-        CryptReleaseContext(hCryptCtx, 0);
--}
+-- C example for windows rng - taken from a blog, can't recall which one but thank you!
+--      #include <Windows.h>
+--      #include <Wincrypt.h>
+--      ...
+--      //
+--      // DISCLAIMER: Don't forget to check your error codes!!
+--      // I am not checking as to make the example simple...
+--      //
+--      HCRYPTPROV hCryptCtx = NULL;
+--      BYTE randomArray[128];
+--
+--      CryptAcquireContext(&hCryptCtx, NULL, MS_DEF_PROV, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT);
+--      CryptGenRandom(hCryptCtx, 128, randomArray);
+--      CryptReleaseContext(hCryptCtx, 0);
 
 
 #ifdef arch_i386


### PR DESCRIPTION
GHC 9.4 on Windows switches from a GCC-based toolchain to a Clang-based one (see [here](https://gitlab.haskell.org/ghc/ghc/-/issues/21019)). One consequence of switching to Clang is that `System.EntropyWindows` will fail to preprocess. For the full details, see the commentary on the GHC issue tracker at [GHC#21668](https://gitlab.haskell.org/ghc/ghc/-/issues/21668). The short version is that this comment in `System.EntropyWindows`:

```hs
{- C example for windows rng - taken from a blog, can't recall which one but thank you!
        #include <Windows.h>
        #include <Wincrypt.h>
        ...
        //
        // DISCLAIMER: Don't forget to check your error codes!!
        // I am not checking as to make the example simple...
        //
        HCRYPTPROV hCryptCtx = NULL;
        BYTE randomArray[128];
        CryptAcquireContext(&hCryptCtx, NULL, MS_DEF_PROV, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT);
        CryptGenRandom(hCryptCtx, 128, randomArray);
        CryptReleaseContext(hCryptCtx, 0);
-}
```

Will be left alone by GCC's preprocessor with `-traditional-cpp` enabled (which is a flag that GHC passes to the C preprocessor), but Clang's preprocessor will expand the `#include`s with `-traditional-cpp` enabled, leading to pandemonium.

This is arguably a bug in Clang, and indeed, there is a FIXME about this particular preprocessor quirk in the Clang test suite
[here](https://github.com/llvm-mirror/clang/blob/aa231e4be75ac4759c236b755c57876f76e3cf05/test/Preprocessor/traditional-cpp.c#L56-L58). That being said, it seems unlikely that this will be fixed any time soon. I've adopted a more expedient fix of switching from `{- ... -}` comments to `--` comments, which prevents the `#include`s from being expanded on both GCC's and Clang's preprocessors.