### PR TITLE
Support unix-2.8.

### DIFF
--- a/System/EntropyNix.hs
+++ b/System/EntropyNix.hs
@@ -34,7 +34,7 @@ import Data.ByteString.Internal as B
 #undef HAVE_RDRAND
 #endif
 
-import System.Posix (openFd, closeFd, fdReadBuf, OpenMode(..), defaultFileFlags, Fd)
+import System.Posix (openFd, closeFd, fdReadBuf, OpenMode(..), defaultFileFlags, Fd, OpenFileFlags(..))
 
 source :: FilePath
 source = "/dev/urandom"
@@ -75,7 +75,11 @@ openHandle =
 openRandomFile :: IO Fd
 openRandomFile = do
   evaluate ensurePoolInitialized
+#if MIN_VERSION_unix(2,8,0)
+  openFd source ReadOnly defaultFileFlags { creat = Nothing }
+#else
   openFd source ReadOnly Nothing defaultFileFlags
+#endif
 
 -- |Close the `CryptHandle`
 closeHandle :: CryptHandle -> IO ()


### PR DESCRIPTION
unix-2.8 changed the type of openFd.  Instead of adding #ifdefs, it's
probably easiest to just require unix-2.8, which works fine on old
GHCs anyway.